### PR TITLE
Tell CMake to compile position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(attention_tracker)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE True)
 add_definitions(-std=c++11)
 
 set(DLIB_PATH "" CACHE PATH "Path to DLIB")

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ support for other operating systems!
 You need to [download](http://dlib.net/) and extract ``Dlib`` somewhere. This
 application has been tested with ``dlib-18.16``.
 
-**Important**: due to a bug in ``dlib``, you **must** manually modify ``dlib``'s
-``CMakeLists.txt`` before compiling: open it
-(``$DLIB_ROOT/dlib/CMakelists.txt``) and add ``add_definitions(-fPIC)`` near the
-top (around line 20).
-
 ### Installation
 
 The library uses a standard ``CMake`` workflow:


### PR DESCRIPTION
It's not a bug in dlib that -fPIC isn't set.  You just have to tell CMake that you want to compile your own project with position independent code :)

Nice project by the way :)
